### PR TITLE
Adding get_type method to NuSDBlockDevice 

### DIFF
--- a/NuSDBlockDevice.cpp
+++ b/NuSDBlockDevice.cpp
@@ -663,4 +663,9 @@ static bool sd_dma_buff_compat(const void *buff, size_t buff_size, size_t size_a
 #endif
 }
 
+const char *NuSDBlockDevice::get_type() const
+{
+    return "NUSD";
+}
+
 #endif  /* TARGET_NUVOTON */

--- a/NuSDBlockDevice.h
+++ b/NuSDBlockDevice.h
@@ -114,6 +114,12 @@ public:
      *  @param          State of debugging
      */
     virtual void debug(bool dbg);
+    
+    /** Get the BlockDevice class type.
+     *
+     *  @return         A string representation of the BlockDevice class type.
+     */
+    virtual const char *get_type() const;
 
 private:
     int _init_sdh();


### PR DESCRIPTION
PR  ARMmbed/mbed-os#9135 has added get_type method to mbed-os 5.11.2 block devices. The change has been done to support the some must have modifications in KVStore in order to support the Pelion client requirements.
This PR is intends to update the NuSDBlockDevice external repo to support the mbed-os v5.11.2.


